### PR TITLE
pi: add guided /pr-summary interview workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ My environment setup.
 - Adds a `review` extension (based on mitsuhiko/agent-stuff) for interactive code review flows (`/review`, `/review bookmark <name>`, `/end-review`) using `jj` workflows.
 - Adds an `auto-qna` extension that detects multiple explicit user-directed clarification questions in final assistant responses (e.g. prompts containing “you/your” or “should I…”), opens an interactive Q&A TUI, and sends captured answers back as a structured JSON follow-up user message (`/auto-qna [on|off|status]`).
 - Includes regression tests for auto-qna question extraction in `pi-agent/extensions/auto-qna/question-extractor.test.ts` (run with `node --test pi-agent/extensions/auto-qna/question-extractor.test.ts`).
+- Adds a `pr-summary-interview` extension command (`/pr-summary`) that runs a required interactive interview with suggested defaults for each PR section, then sends structured answers to `pr-summary` skill generation (non-interactive mode is intentionally unsupported for this flow).
 - Adds a `jj-footer` extension that replaces git `(detached)` branch display with jj-aware status (`jj:<bookmark>` or `jj:@<change-id>`) while keeping the default footer layout/metrics (session name, token/cache totals, cost, context usage, model, extension statuses).
 - Uses a custom `catppuccin` theme (Mocha palette) defined in `pi-agent/themes/catppuccin.json`, with neutral tool-call card backgrounds and softer diff colors to better match the palette.
 

--- a/pi-agent/extensions/pr-summary-interview.ts
+++ b/pi-agent/extensions/pr-summary-interview.ts
@@ -1,0 +1,672 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { Editor, type EditorTheme, Key, matchesKey, truncateToWidth } from "@mariozechner/pi-tui";
+
+type DiffEntry = {
+  status: string;
+  path: string;
+};
+
+type DiffContext = {
+  source: "jj" | "git" | "none";
+  summary: string;
+  changes: DiffEntry[];
+};
+
+type InterviewSections = {
+  highLevelSummary: string;
+  why: string;
+  sessionContext: string;
+  keyDecisions: string;
+  alternatives: string;
+  tradeoffsAndRisks: string;
+  testsChanged: string;
+  reviewerNotes: string;
+};
+
+type InterviewQuestion = {
+  key: keyof InterviewSections;
+  label: string;
+  prompt: string;
+};
+
+type ExecResult = {
+  stdout: string;
+  stderr: string;
+  code: number;
+  killed?: boolean;
+};
+
+const MAX_DIFF_SUMMARY_CHARS = 3000;
+const MAX_INTENT_CHARS = 240;
+
+const INTERVIEW_QUESTIONS: InterviewQuestion[] = [
+  {
+    key: "highLevelSummary",
+    label: "High-level summary",
+    prompt: "Summarize what changed in 1-3 reviewer-friendly bullets.",
+  },
+  {
+    key: "why",
+    label: "Why",
+    prompt: "Describe the motivation and problem this change addresses.",
+  },
+  {
+    key: "sessionContext",
+    label: "Session context",
+    prompt: "Capture scope, assumptions, constraints, and notable context from the session.",
+  },
+  {
+    key: "keyDecisions",
+    label: "Key decisions made",
+    prompt: "List decisions and rationale (Decision + Why).",
+  },
+  {
+    key: "alternatives",
+    label: "Alternatives considered",
+    prompt: "List important alternatives and why they were rejected.",
+  },
+  {
+    key: "tradeoffsAndRisks",
+    label: "Trade-offs and risks",
+    prompt: "Document trade-offs, risk areas, and compatibility impact.",
+  },
+  {
+    key: "testsChanged",
+    label: "Tests changed",
+    prompt: "Capture Added/Updated/Removed/Not run details.",
+  },
+  {
+    key: "reviewerNotes",
+    label: "Notes for reviewer",
+    prompt: "Mention caveats, follow-ups, and likely review hotspots.",
+  },
+];
+
+function cleanText(value: string): string {
+  return value.replace(/\r\n/g, "\n").trim();
+}
+
+function normalizeAnswer(value: string): string {
+  const cleaned = cleanText(value);
+  return cleaned.length > 0 ? cleaned : "Not available";
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 3))}...`;
+}
+
+function parseJjSummary(stdout: string): DiffEntry[] {
+  const changes: DiffEntry[] = [];
+
+  for (const line of stdout.split("\n")) {
+    const match = line.trim().match(/^([A-Z])\s+(.+)$/);
+    if (!match) continue;
+
+    const status = match[1] ?? "M";
+    const rawPath = match[2] ?? "";
+    const path = extractFinalPath(rawPath);
+    if (!path) continue;
+
+    changes.push({ status, path });
+  }
+
+  return dedupeChanges(changes);
+}
+
+function parseGitNameStatus(stdout: string): DiffEntry[] {
+  const changes: DiffEntry[] = [];
+
+  for (const line of stdout.split("\n")) {
+    if (!line.trim()) continue;
+
+    const parts = line.split("\t").map((item) => item.trim()).filter(Boolean);
+    if (parts.length < 2) continue;
+
+    const status = parts[0]?.charAt(0) ?? "M";
+    const path = parts[parts.length - 1] ?? "";
+    if (!path) continue;
+
+    changes.push({ status, path });
+  }
+
+  return dedupeChanges(changes);
+}
+
+function extractFinalPath(rawPath: string): string {
+  const trimmed = rawPath.trim();
+  if (!trimmed) return "";
+
+  const renameArrow = trimmed.lastIndexOf(" => ");
+  if (renameArrow >= 0) {
+    return trimmed.slice(renameArrow + 4).trim();
+  }
+
+  return trimmed;
+}
+
+function dedupeChanges(changes: DiffEntry[]): DiffEntry[] {
+  const byPath = new Map<string, DiffEntry>();
+  for (const change of changes) {
+    byPath.set(change.path, change);
+  }
+  return Array.from(byPath.values());
+}
+
+function mapStatus(status: string): string {
+  switch (status) {
+    case "A":
+      return "added";
+    case "D":
+      return "removed";
+    case "R":
+      return "renamed";
+    case "C":
+      return "copied";
+    case "M":
+    default:
+      return "modified";
+  }
+}
+
+function formatStatusSummary(changes: DiffEntry[]): string {
+  if (changes.length === 0) return "no detected file changes";
+
+  const counts = new Map<string, number>();
+  for (const change of changes) {
+    const label = mapStatus(change.status);
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([label, count]) => `${count} ${label}`)
+    .join(", ");
+}
+
+function topAreas(paths: string[]): string[] {
+  const counts = new Map<string, number>();
+
+  for (const path of paths) {
+    const normalized = path.replace(/^\.\//, "");
+    const firstSegment = normalized.includes("/") ? normalized.split("/")[0] : "(repo root)";
+    counts.set(firstSegment, (counts.get(firstSegment) ?? 0) + 1);
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([area]) => area);
+}
+
+function isTestPath(path: string): boolean {
+  const lower = path.toLowerCase();
+  return /(^|\/)(test|tests|spec|specs)(\/|$)/.test(lower) || /(test|spec)\.[^/]+$/.test(lower) || /_test\.[^/]+$/.test(lower);
+}
+
+function toList(items: string[]): string {
+  if (items.length === 0) return "  - Not available";
+  return items.map((item) => `  - ${item}`).join("\n");
+}
+
+function getTextFromMessageContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  return content
+    .filter((block) => block && typeof block === "object" && (block as { type?: string }).type === "text")
+    .map((block) => ((block as { text?: unknown }).text as string | undefined) ?? "")
+    .join("\n");
+}
+
+function latestUserIntent(ctx: ExtensionCommandContext): string | undefined {
+  const entries = ctx.sessionManager.getBranch();
+
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    const entry = entries[i];
+    if (entry.type !== "message") continue;
+
+    const message = entry.message as { role?: string; content?: unknown };
+    if (message.role !== "user") continue;
+
+    const text = cleanText(getTextFromMessageContent(message.content));
+    if (!text) continue;
+    if (text.startsWith("/")) continue;
+    if (text.includes("Structured PR interview answers")) continue;
+
+    return truncate(text.replace(/\s+/g, " "), MAX_INTENT_CHARS);
+  }
+
+  return undefined;
+}
+
+async function runExec(
+  pi: ExtensionAPI,
+  command: string,
+  args: string[],
+  timeout = 15_000,
+): Promise<ExecResult> {
+  try {
+    const result = (await pi.exec(command, args, { timeout })) as ExecResult;
+    return {
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      code: result.code ?? 1,
+      killed: result.killed,
+    };
+  } catch (error) {
+    return {
+      stdout: "",
+      stderr: error instanceof Error ? error.message : String(error),
+      code: 1,
+    };
+  }
+}
+
+async function collectDiffContext(pi: ExtensionAPI): Promise<DiffContext> {
+  const jjDiff = await runExec(pi, "jj", ["diff", "--summary"]);
+  if (jjDiff.code === 0) {
+    const changes = parseJjSummary(jjDiff.stdout);
+
+    if (changes.length > 0 || cleanText(jjDiff.stdout).length > 0) {
+      return {
+        source: "jj",
+        summary: cleanText(jjDiff.stdout) || "Not available",
+        changes,
+      };
+    }
+
+    const jjShow = await runExec(pi, "jj", ["show", "@", "--summary"]);
+    if (jjShow.code === 0) {
+      const showChanges = parseJjSummary(jjShow.stdout);
+      if (showChanges.length > 0 || cleanText(jjShow.stdout).length > 0) {
+        return {
+          source: "jj",
+          summary: cleanText(jjShow.stdout) || "Not available",
+          changes: showChanges,
+        };
+      }
+    }
+  }
+
+  const gitDiff = await runExec(pi, "git", ["diff", "--name-status"]);
+  if (gitDiff.code === 0) {
+    const changes = parseGitNameStatus(gitDiff.stdout);
+    if (changes.length > 0 || cleanText(gitDiff.stdout).length > 0) {
+      return {
+        source: "git",
+        summary: cleanText(gitDiff.stdout) || "Not available",
+        changes,
+      };
+    }
+  }
+
+  const gitShow = await runExec(pi, "git", ["show", "--name-status", "--pretty=format:", "HEAD"]);
+  if (gitShow.code === 0) {
+    const changes = parseGitNameStatus(gitShow.stdout);
+    if (changes.length > 0 || cleanText(gitShow.stdout).length > 0) {
+      return {
+        source: "git",
+        summary: cleanText(gitShow.stdout) || "Not available",
+        changes,
+      };
+    }
+  }
+
+  return {
+    source: "none",
+    summary: "Not available",
+    changes: [],
+  };
+}
+
+function buildDefaults(diff: DiffContext, userIntent?: string): InterviewSections {
+  const paths = diff.changes.map((change) => change.path);
+  const areas = topAreas(paths);
+  const statusSummary = formatStatusSummary(diff.changes);
+  const notableFiles = paths.slice(0, 5);
+
+  const highLevelSummary =
+    paths.length === 0
+      ? "- Not available"
+      : [
+          `- Updated ${paths.length} file${paths.length === 1 ? "" : "s"} (${statusSummary}).`,
+          `- Main areas touched: ${areas.length > 0 ? areas.join(", ") : "Not available"}.`,
+          `- Notable files: ${notableFiles.map((file) => `\`${file}\``).join(", ")}.`,
+        ].join("\n");
+
+  const why = userIntent
+    ? [
+        `Requested change: ${userIntent}`,
+        "This PR aligns the implementation with the requested behavior while keeping scope focused on the changed files.",
+      ].join("\n")
+    : "Not available";
+
+  const sessionContext = [
+    `- Scope: ${paths.length > 0 ? `${paths.length} changed file${paths.length === 1 ? "" : "s"}` : "Not available"}.`,
+    `- Inputs/constraints: ${userIntent ? `User request was: ${userIntent}` : "Not available"}.`,
+    `- Diff source: ${diff.source}.`,
+  ].join("\n");
+
+  const keyDecisions =
+    "- Decision: Keep the change scoped to the touched files and existing patterns.\n  - Why: Minimize review surface area and avoid unrelated refactors.";
+
+  const alternatives =
+    "- Alternative: Broader refactor across adjacent modules.\n  - Why not chosen: Would increase risk and review complexity for this PR scope.";
+
+  const tradeoffsAndRisks =
+    "- Keeping scope narrow improves reviewability but may leave related cleanup for follow-up PRs.";
+
+  const addedTests: string[] = [];
+  const updatedTests: string[] = [];
+  const removedTests: string[] = [];
+
+  for (const change of diff.changes) {
+    if (!isTestPath(change.path)) continue;
+
+    if (change.status === "A") {
+      addedTests.push(change.path);
+      continue;
+    }
+
+    if (change.status === "D") {
+      removedTests.push(change.path);
+      continue;
+    }
+
+    updatedTests.push(change.path);
+  }
+
+  const testsChanged = [
+    "- **Added**:",
+    toList(addedTests),
+    "- **Updated**:",
+    toList(updatedTests),
+    "- **Removed**:",
+    toList(removedTests),
+    "- **Not run / blocked**:",
+    "  - Not available",
+  ].join("\n");
+
+  const reviewerNotes =
+    notableFiles.length > 0
+      ? `- Focus review on: ${notableFiles.map((file) => `\`${file}\``).join(", ")}.`
+      : "- Not available";
+
+  return {
+    highLevelSummary,
+    why,
+    sessionContext,
+    keyDecisions,
+    alternatives,
+    tradeoffsAndRisks,
+    testsChanged,
+    reviewerNotes,
+  };
+}
+
+function normalizeSections(sections: InterviewSections): InterviewSections {
+  return {
+    highLevelSummary: normalizeAnswer(sections.highLevelSummary),
+    why: normalizeAnswer(sections.why),
+    sessionContext: normalizeAnswer(sections.sessionContext),
+    keyDecisions: normalizeAnswer(sections.keyDecisions),
+    alternatives: normalizeAnswer(sections.alternatives),
+    tradeoffsAndRisks: normalizeAnswer(sections.tradeoffsAndRisks),
+    testsChanged: normalizeAnswer(sections.testsChanged),
+    reviewerNotes: normalizeAnswer(sections.reviewerNotes),
+  };
+}
+
+async function collectInterviewAnswers(
+  ctx: ExtensionCommandContext,
+  defaults: InterviewSections,
+): Promise<InterviewSections | null> {
+  if (!ctx.hasUI) return null;
+
+  const normalizedDefaults = normalizeSections(defaults);
+
+  return ctx.ui.custom<InterviewSections | null>((tui, theme, _kb, done) => {
+    let currentIndex = 0;
+    let cachedLines: string[] | undefined;
+
+    const answers: InterviewSections = {
+      ...normalizedDefaults,
+    };
+    const reviewed = new Set<keyof InterviewSections>();
+
+    const editorTheme: EditorTheme = {
+      borderColor: (s) => theme.fg("accent", s),
+      selectList: {
+        selectedPrefix: (t) => theme.fg("accent", t),
+        selectedText: (t) => theme.fg("accent", t),
+        description: (t) => theme.fg("muted", t),
+        scrollInfo: (t) => theme.fg("dim", t),
+        noMatch: (t) => theme.fg("warning", t),
+      },
+    };
+
+    const editor = new Editor(tui, editorTheme);
+
+    const currentQuestion = () => INTERVIEW_QUESTIONS[currentIndex] ?? INTERVIEW_QUESTIONS[0]!;
+
+    const refresh = () => {
+      cachedLines = undefined;
+      tui.requestRender();
+    };
+
+    const saveCurrentAnswer = () => {
+      const question = currentQuestion();
+      answers[question.key] = normalizeAnswer(editor.getText());
+      reviewed.add(question.key);
+    };
+
+    const switchTo = (index: number) => {
+      saveCurrentAnswer();
+      currentIndex = index;
+      const nextQuestion = currentQuestion();
+      editor.setText(answers[nextQuestion.key]);
+      refresh();
+    };
+
+    const submitAll = () => {
+      saveCurrentAnswer();
+      done({ ...answers });
+    };
+
+    editor.setText(answers[currentQuestion().key]);
+
+    editor.onSubmit = (value) => {
+      const question = currentQuestion();
+      answers[question.key] = normalizeAnswer(value);
+      reviewed.add(question.key);
+
+      if (currentIndex < INTERVIEW_QUESTIONS.length - 1) {
+        currentIndex += 1;
+        editor.setText(answers[currentQuestion().key]);
+        refresh();
+        return;
+      }
+
+      done({ ...answers });
+    };
+
+    function handleInput(data: string) {
+      if (matchesKey(data, Key.escape)) {
+        done(null);
+        return;
+      }
+
+      if (matchesKey(data, Key.ctrl("s"))) {
+        submitAll();
+        return;
+      }
+
+      if (matchesKey(data, Key.tab) || matchesKey(data, Key.right) || matchesKey(data, Key.ctrl("n"))) {
+        const next = (currentIndex + 1) % INTERVIEW_QUESTIONS.length;
+        switchTo(next);
+        return;
+      }
+
+      if (matchesKey(data, Key.shift("tab")) || matchesKey(data, Key.left) || matchesKey(data, Key.ctrl("p"))) {
+        const previous = (currentIndex - 1 + INTERVIEW_QUESTIONS.length) % INTERVIEW_QUESTIONS.length;
+        switchTo(previous);
+        return;
+      }
+
+      editor.handleInput(data);
+      refresh();
+    }
+
+    function render(width: number): string[] {
+      if (cachedLines) return cachedLines;
+
+      const lines: string[] = [];
+      const horizontal = "─".repeat(Math.max(1, width));
+      const question = currentQuestion();
+      const total = INTERVIEW_QUESTIONS.length;
+      const maxLabelLength = `Q${total}`.length;
+
+      const overrideCount = INTERVIEW_QUESTIONS.filter((item) => {
+        const defaultValue = normalizedDefaults[item.key];
+        const answerValue = item.key === question.key ? normalizeAnswer(editor.getText()) : answers[item.key];
+        return cleanText(defaultValue) !== cleanText(answerValue);
+      }).length;
+
+      const reviewedCount = INTERVIEW_QUESTIONS.filter((item) => {
+        if (reviewed.has(item.key)) return true;
+        if (item.key !== question.key) return false;
+
+        const currentDraft = normalizeAnswer(editor.getText());
+        return cleanText(currentDraft) !== cleanText(normalizedDefaults[item.key]);
+      }).length;
+
+      const add = (text: string) => {
+        lines.push(truncateToWidth(text, width));
+      };
+
+      add(theme.fg("accent", horizontal));
+      add(theme.fg("accent", theme.bold(` PR summary interview (${currentIndex + 1}/${total})`)));
+      lines.push("");
+
+      const chips = INTERVIEW_QUESTIONS.map((item, index) => {
+        const active = index === currentIndex;
+        const defaultValue = normalizedDefaults[item.key];
+        const answerValue = item.key === question.key ? normalizeAnswer(editor.getText()) : answers[item.key];
+        const overridden = cleanText(defaultValue) !== cleanText(answerValue);
+        const isReviewed = reviewed.has(item.key) || (item.key === question.key && overridden);
+        const marker = overridden ? "~" : isReviewed ? "✓" : " ";
+        const label = `Q${index + 1}`.padEnd(maxLabelLength, " ");
+        const chipCore = `${marker} ${label}`;
+
+        if (active) {
+          return theme.fg("accent", `[${chipCore}]`);
+        }
+
+        return theme.fg(overridden ? "warning" : isReviewed ? "success" : "muted", ` ${chipCore} `);
+      }).join(" ");
+
+      add(` ${chips}`);
+      lines.push("");
+      add(theme.fg("text", ` ${question.label}`));
+      add(theme.fg("muted", ` ${question.prompt}`));
+      lines.push("");
+      add(theme.fg("muted", " Answer (suggested default is prefilled; edit to override):"));
+
+      for (const line of editor.render(Math.max(20, width - 2))) {
+        add(` ${line}`);
+      }
+
+      lines.push("");
+      add(
+        theme.fg(
+          "dim",
+          ` Enter next/submit • Tab/Shift+Tab or ←/→ switch • Ctrl+S submit all • Esc cancel (${reviewedCount}/${total} reviewed, ${overrideCount}/${total} overridden)`,
+        ),
+      );
+      add(theme.fg("accent", horizontal));
+
+      cachedLines = lines;
+      return lines;
+    }
+
+    return {
+      render,
+      invalidate() {
+        cachedLines = undefined;
+        editor.invalidate();
+      },
+      handleInput,
+    };
+  });
+}
+
+function buildInterviewPayload(diff: DiffContext, sections: InterviewSections) {
+  return {
+    type: "pr_summary_interview_answers",
+    source: "pr-summary-interview",
+    generated_at: new Date().toISOString(),
+    diff_context: {
+      source: diff.source,
+      summary: truncate(diff.summary || "Not available", MAX_DIFF_SUMMARY_CHARS),
+      changed_files: diff.changes,
+    },
+    sections: {
+      high_level_summary: sections.highLevelSummary,
+      why: sections.why,
+      session_context: sections.sessionContext,
+      key_decisions_made: sections.keyDecisions,
+      alternatives_considered: sections.alternatives,
+      tradeoffs_and_risks: sections.tradeoffsAndRisks,
+      tests_changed: sections.testsChanged,
+      notes_for_reviewer: sections.reviewerNotes,
+    },
+  };
+}
+
+function buildSkillPrompt(payload: ReturnType<typeof buildInterviewPayload>): string {
+  return [
+    "/skill:pr-summary Generate the PR body using these interview answers and diff context. Treat the interview answers as authoritative. Do not ask follow-up interview questions.",
+    "",
+    "Structured PR interview answers:",
+    "```json",
+    JSON.stringify(payload, null, 2),
+    "```",
+  ].join("\n");
+}
+
+export default function prSummaryInterviewExtension(pi: ExtensionAPI) {
+  pi.registerCommand("pr-summary", {
+    description: "Run an interactive PR-summary interview with suggested defaults, then draft the PR body",
+    handler: async (_args, ctx) => {
+      if (!ctx.hasUI) {
+        ctx.ui.notify("/pr-summary requires interactive Pi UI. Non-interactive mode is not supported.", "error");
+        return;
+      }
+
+      const diff = await collectDiffContext(pi);
+      const intent = latestUserIntent(ctx);
+      const defaults = buildDefaults(diff, intent);
+
+      const sections = await collectInterviewAnswers(ctx, defaults);
+      if (!sections) {
+        ctx.ui.notify("PR summary interview cancelled.", "info");
+        return;
+      }
+
+      const payload = buildInterviewPayload(diff, sections);
+      const proceed = await ctx.ui.confirm(
+        "Generate PR body now?",
+        "This will send the captured interview answers to the pr-summary skill.",
+      );
+
+      if (!proceed) {
+        ctx.ui.notify("PR summary interview complete; generation skipped. Re-run /pr-summary when ready.", "info");
+        return;
+      }
+
+      pi.sendUserMessage(buildSkillPrompt(payload));
+      ctx.ui.notify("Interview complete. Drafting PR body...", "info");
+    },
+  });
+}

--- a/skills/pr-summary/SKILL.md
+++ b/skills/pr-summary/SKILL.md
@@ -2,22 +2,30 @@
 name: pr-summary
 description: Generate reviewer-ready PR bodies with high-level changes, rationale, session context, decisions, alternatives, trade-offs, and test impact. Always use when creating or editing a PR body for agent-authored changes.
 license: Proprietary
-compatibility: Requires access to git/jj diff context and the agent session notes.
+compatibility: Requires interactive Pi with the /pr-summary extension command.
 metadata:
   author: paulthomson
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Purpose
-Create consistent, high-signal PR descriptions that help a reviewer understand not only what changed, but also how/why it was changed.
+Create consistent, high-signal PR descriptions that explain what changed and why.
 
-# When to use
-Use this skill when:
-- You are preparing a PR body from agent work.
-- You are creating a PR (`gh pr create`) or editing an existing PR body (`gh pr edit`) for agent-authored changes.
-- The user asks for "make a PR", "open a PR", or similar phrasing.
-- You need to explain implementation choices and alternatives considered.
-- You need to report test changes (added/changed/removed/not run).
+# Mandatory workflow (no fallback)
+This skill requires structured interview input produced by the `/pr-summary` extension command.
+
+1. User runs `/pr-summary` in interactive Pi.
+2. The extension interviews the user section-by-section with suggested defaults.
+3. The extension sends a JSON payload in chat with:
+   - `type: "pr_summary_interview_answers"`
+   - section answers under `sections`
+   - diff context under `diff_context`
+4. This skill renders the final PR body from that payload.
+
+If that payload is missing, stop and reply:
+`Please run /pr-summary in interactive Pi first.`
+
+Do not run free-form fallback interviews in chat.
 
 # Required output sections
 Fill **all** sections; if data is unavailable, state `Not available` explicitly.
@@ -29,19 +37,19 @@ Fill **all** sections; if data is unavailable, state `Not available` explicitly.
 Explain the problem and the motivation for the change.
 
 ## 3) Session context
-Capture the high-level context from the agent session, including:
+Capture high-level context from the session, including:
 - Scope and assumptions
 - Inputs/constraints
-- Any important context from prior decisions or discussion
+- Important prior context/decisions
 
 ## 4) Key decisions made
 List each decision and rationale.
 
 ## 5) Alternatives considered
-For each important decision, list the alternatives reviewed and why they were rejected.
+For each important decision, list alternatives reviewed and why they were rejected.
 
 ## 6) Trade-offs and risks
-Include explicit trade-offs, compatibility or migration impact, and any known risks.
+Include explicit trade-offs, compatibility or migration impact, and known risks.
 
 ## 7) Tests changed
 - **Added**: tests added and what they cover
@@ -50,15 +58,13 @@ Include explicit trade-offs, compatibility or migration impact, and any known ri
 - **Not run / blocked**: why tests were not run
 
 ## 8) Notes for reviewer
-- Any caveats, follow-ups, or likely review hotspots.
+Any caveats, follow-ups, or likely review hotspots.
 
-# Recommended workflow
-1. Collect changed files and summary of code changes.
-2. Capture rationale from the issue/goal and session notes.
-3. Capture decisions, alternatives considered, and trade-offs.
-4. Capture test status: added/updated/removed and anything not run.
-5. Render the PR body in the exact section order above.
-6. If a PR was already created with a short/incomplete body, regenerate with this skill and immediately update via `gh pr edit --body-file`.
+# Rendering rules
+- Use interview payload answers as authoritative source of truth.
+- Keep section order exactly as defined above.
+- Preserve explicit `Not available` values.
+- Keep language concise and reviewer-friendly.
 
 # PR body template
 ```markdown
@@ -98,5 +104,5 @@ Include explicit trade-offs, compatibility or migration impact, and any known ri
 
 # Success criteria
 - Every required section is present.
-- Why + trade-off rationale is explicit (no vague claims).
-- If no data exists for a section, explicitly state that it is missing.
+- Why + trade-off rationale is explicit.
+- No section is omitted; missing data is explicitly `Not available`.


### PR DESCRIPTION
## High-level summary
- Added a new interactive `/pr-summary` extension command that interviews the user section-by-section and pre-fills each answer with a suggested default.
- Updated the `pr-summary` skill to require structured interview payloads from the extension and explicitly reject non-interactive/free-form fallback flows.
- Documented the new workflow in `README.md` under the Pi extensions section.

## Why
- PR descriptions were often missing reliable motivation details (especially the “why”) when generated ad hoc from free-form prompts.
- A guided interview with suggested defaults makes it easier to capture complete reviewer context consistently before generating the final PR body.
- The workflow intentionally assumes interactive Pi usage to reduce ambiguity and avoid maintaining a second fallback path.

## Session context
- Scope and assumptions: implement an interactive, default-suggesting PR interview workflow and keep it extension-driven.
- Inputs/constraints: user explicitly requested no fallback behavior and asked to proceed with implementation.
- Prior context: `pr-summary` already required rich sections; this change focuses on collecting those sections more reliably up front.

## Key decisions made
- Decision: implement interview collection as a new Pi extension command (`/pr-summary`) rather than only changing skill prose.
  - Why: extension UI supports true interactive prompts with editable defaults and explicit accept/override behavior.
- Decision: pass collected answers as a structured JSON payload back to the skill.
  - Why: keeps generation deterministic and allows the skill to render from authoritative inputs.
- Decision: enforce no fallback in the skill when structured payload is missing.
  - Why: matches the requested “interactive-only” behavior and avoids split logic paths.

## Alternatives considered
- Alternative: keep a skill-only chat interview without extension UI.
  - Why not chosen: weaker UX for accept/override defaults and more brittle parsing of responses.
- Alternative: support both interactive and non-interactive fallback paths.
  - Why not chosen: explicitly rejected by request; would add maintenance and behavior ambiguity.

## Trade-offs and risks
- The workflow now depends on interactive Pi UI; non-interactive usage intentionally fails fast.
- Suggested defaults are heuristic (diff/session-derived), so users still need to review and adjust responses for accuracy.
- The new command introduces additional extension logic (diff parsing and prompt orchestration) that may need future refinement for edge-case diffs.

## Tests changed
- **Added**:
  - Not available
- **Updated**:
  - Not available
- **Removed**:
  - Not available
- **Not run / blocked**:
  - No dedicated test suite was added for this extension command in this change.
  - A local TypeScript check was attempted, but module type resolution for `@mariozechner/pi-coding-agent` is not configured in this repo’s standalone `tsc` invocation.

## Notes for reviewer
- Main review hotspots: `pi-agent/extensions/pr-summary-interview.ts` default generation + interactive section capture, and `skills/pr-summary/SKILL.md` enforcement of the new required payload.
- Confirm the extension auto-load behavior in your Pi setup includes `pi-agent/extensions/*.ts`.